### PR TITLE
Fix banner escape warning

### DIFF
--- a/certcrunchy.py
+++ b/certcrunchy.py
@@ -19,7 +19,8 @@ from time import sleep
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-_banner = """\033[1;33;49m
+_banner = (
+    "\033[1;33;49m" + r"""
  _____           _   _____                       _
 /  __ \         | | /  __ \                     | |
 | /  \/ ___ _ __| |_| /  \/_ __ _   _ _ __   ___| |__  _   _
@@ -28,9 +29,14 @@ _banner = """\033[1;33;49m
  \____/\___|_|   \__|\____/_|   \__,_|_| |_|\___|_| |_|\__, |
                                                         __/ |
                                                        |___/
-    \033[1;31;49mJust a silly recon tool...
-    @_w_m__\033[0;37;49m
+    """
+    + "\033[1;31;49m"
+    + """Just a silly recon tool...
+    @_w_m__"""
+    + "\033[0;37;49m"
+    + """
 """
+)
 
 _transparency_endpoint = "https://crt.sh/?q=%.{query}&output=json"
 _censys_endpoint = "https://www.censys.io/api/v1"


### PR DESCRIPTION
Partially addresses #7.

The current `master` branch already has the hostname regex written as a raw string, but the banner still contains ASCII-art backslashes inside a normal string literal. Python 3.14 reports those as invalid escape sequences before the script reaches runtime.

This keeps the ANSI color escape sequences interpreted while making the ASCII-art portion a raw string, so importing/running the script no longer warns on that banner literal.

I intentionally did not change the pinned `requests`/`urllib3` dependency issue shown later in #7, because that is separate from this warning and is already covered by Dependabot PR #5.

Not run locally.
Static whitespace validation: `git diff --check HEAD~1..HEAD`, which passed.